### PR TITLE
Fixing Sass build in GHA

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   checks:
-    runs-on: macos-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Checkout

--- a/packages/copper/src/05_layout/_index.scss
+++ b/packages/copper/src/05_layout/_index.scss
@@ -1,3 +1,3 @@
-// @use "center";
-// @use "stack";
-// @use "sidebar";
+@use "center";
+@use "stack";
+@use "sidebar";

--- a/packages/copper/src/05_layout/_index.scss
+++ b/packages/copper/src/05_layout/_index.scss
@@ -1,3 +1,3 @@
-@use "center";
-@use "stack";
-@use "sidebar";
+// @use "center";
+// @use "stack";
+// @use "sidebar";


### PR DESCRIPTION
Seems like our build command for Sass breaks when we use `ubuntu-latest` in our actions.