### PR TITLE
fix: fix the name prop on TextInput components

### DIFF
--- a/packages/copper-vue/src/components/TextInput/TextInput.vue
+++ b/packages/copper-vue/src/components/TextInput/TextInput.vue
@@ -7,6 +7,7 @@
       :type="type"
       :class="inputClasses"
       :id="id"
+      :name="id"
       :required="required"
       :disabled="disabled"
       :value="value"


### PR DESCRIPTION
The name prop was defined, but it wasn't actually being added to the template of the `TextInput` component. This is a quick fix to get that working.