### PR TITLE
fix: text input name prop has correct value

### DIFF
--- a/packages/copper-vue/src/components/TextInput/TextInput.vue
+++ b/packages/copper-vue/src/components/TextInput/TextInput.vue
@@ -7,7 +7,7 @@
       :type="type"
       :class="inputClasses"
       :id="id"
-      :name="id"
+      :name="name"
       :required="required"
       :disabled="disabled"
       :value="value"


### PR DESCRIPTION
The name prop was being given the id value, and this fixes that.