### PR TITLE
Add github token to changeset action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,5 @@ jobs:
         commit: "chore: update versions"
         title: "chore: update versions"
         publish: pnpm ci:publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The action from `changesets` we use to publish packages needs the `GITHUB_TOKEN` to be added.