### PR TITLE
build: removes unnecessary pnpm commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CI: true
-  PNPM_CACHE_FOLDER: .pnpm-store
 
 jobs:
   version-and-release:
@@ -16,8 +15,6 @@ jobs:
     steps:
     - name: Checkout code repo
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     
     - name: Setup Node 16
       uses: actions/setup-node@v2
@@ -29,9 +26,6 @@ jobs:
 
     - name: Setup .npmrc file
       run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-
-    - name: Setup pnpm config
-      run: pnpm config set store-dir $PNPM_CACHE_FOLDER
 
     - name: Install dependencies
       ## We're in CI env so --frozen-lockfile is used by default here, fails if there is


### PR DESCRIPTION
See [this issue](https://github.com/changesets/action/issues/146) on how to stop the pnpm cache store from being added to git.