### PR TITLE
chore: add .npmrc file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
-
 .vscode
+
+.npmrc


### PR DESCRIPTION
Our changesets action needs a .npmrc file to be present, and then it commits all the changes in the working directory. We're adding that file to gitignore so our npm token doesn't get committed.