### PR TITLE
fix: add color to number and datepicker inputs when form is validate

### DIFF
--- a/.changeset/pink-maps-fetch.md
+++ b/.changeset/pink-maps-fetch.md
@@ -1,0 +1,5 @@
+---
+"@blueconduit/copper": patch
+---
+
+Add validation styles for number text inputs

--- a/packages/copper/src/06_components/form/_form.scss
+++ b/packages/copper/src/06_components/form/_form.scss
@@ -19,7 +19,6 @@
     select:invalid,
     input[type='text']:invalid,
     input[type='number']:invalid,
-    input.datepicker,
     textarea:invalid {
       border-color: dt.$notification_error;
 
@@ -35,7 +34,6 @@
     select:valid,
     input[type='text']:valid,
     input[type='number']:valid,
-    input.datepicker,
     textarea:valid {
       border-color: dt.$notification_success;
       

--- a/packages/copper/src/06_components/form/_form.scss
+++ b/packages/copper/src/06_components/form/_form.scss
@@ -18,6 +18,8 @@
     &
     select:invalid,
     input[type='text']:invalid,
+    input[type='number']:invalid,
+    input.datepicker,
     textarea:invalid {
       border-color: dt.$notification_error;
 
@@ -32,6 +34,8 @@
     &
     select:valid,
     input[type='text']:valid,
+    input[type='number']:valid,
+    input.datepicker,
     textarea:valid {
       border-color: dt.$notification_success;
       

--- a/packages/copper/src/06_components/text-input/text-input.html
+++ b/packages/copper/src/06_components/text-input/text-input.html
@@ -18,6 +18,12 @@
         <span class="cu-form__invalid-text">Uh oh, this field is required!</span>
       </div>
       <div class="cu-form__group">
+        <label class="cu-form__label" for="number">Number input *</label>
+        <input class="cu-text-input" type="number" name="number" id="number" required>
+        <span class="cu-form__help-text">This value has to be a number</span>
+        <span class="cu-form__invalid-text">Uh oh, this field has to be a number!</span>
+      </div>
+      <div class="cu-form__group">
         <label class="cu-form__label" for="focused">Second input</label>
         <input class="cu-text-input" type="text" name="second" id="second">
       </div>


### PR DESCRIPTION
## Description

Addresses: [card#149](https://trello.com/c/nciX1cnO/149-updating-service-line-records-notify-user-when-required-fields-need-attention)

### Changed

- Handle number input and input with datepicker class when valid/invalid state change whenever a form is validated

